### PR TITLE
Feature/add schemas endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Fhirball Server
 
-This is a RESTful API to serve data to the client.
+This is a RESTful API to serve data to the client. It is mainly routes requests to back-ends running on the same machine which respectively contain and serve all needed data.
 
 ## Installation
 
@@ -20,6 +20,13 @@ Otherwise, run:
 ```
 python3 ./server.py
 ```
+
+## Available resources
+
+### Schemas
+
+* `[url]/schemas` returns a CSV list of available database schemas.
+* `[url]/schema/<database_name>/<extension>` returns a file containing the schema of a given database.
 
 ### Store
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,16 @@ This is a RESTful API to serve data to the client.
 
 ## Installation
 
-Python modules should be installed first: `pip install requirements.txt`.
-
+Python modules should be installed first: `pip install requirements.txt`. This file was generated unsing `pipreqs --force ./`.
 
 ## Usage
 
-In order to start the server, run the following command:
+In order to start the server in a development environment, run the following command:
+```
+FLASK_ENV=development python3 ./server.py
+```
+
+Otherwise, run:
 ```
 python3 ./server.py
 ```

--- a/api/resources/__init__.py
+++ b/api/resources/__init__.py
@@ -1,1 +1,1 @@
-from .resources import Mapping, Schemas, Store
+from .resources import Mapping, Schema, Schemas, Store

--- a/api/resources/__init__.py
+++ b/api/resources/__init__.py
@@ -1,1 +1,1 @@
-from .resources import Mapping, Store
+from .resources import Mapping, Schemas, Store

--- a/api/resources/resources.py
+++ b/api/resources/resources.py
@@ -1,36 +1,14 @@
-from flask import jsonify, send_from_directory
+from flask import jsonify, make_response, send_from_directory
 # note: prefer send_from_directory to send_file  as send_file is not secured.
 # From the official documentation : "Please never pass filenames to this function from user sources;
 # you should use send_from_directory() instead."
 from flask_restful import Resource, reqparse
+import json
 import os
+import requests
 import yaml
 
 from api.common.utils import fhir_resource_path
-
-
-class Store(Resource):
-    def post(self):
-
-        parser = reqparse.RequestParser()
-        parser.add_argument('output_format', required=True, type=str, choices=('json', 'yml'))
-        parser.add_argument('fhir_resource_name', required=True, type=str)
-
-        args = parser.parse_args()
-
-        file_path = fhir_resource_path(args['fhir_resource_name'], parent_folder=args['output_format'])
-        if not file_path:
-            return jsonify(
-                {"message": "Fhir resource not found."}
-            )
-
-        folder = os.path.dirname(file_path)
-        file = os.path.basename(file_path)
-        if args['output_format'] == 'json':
-            return jsonify(yaml.load(open(file_path)))
-
-        elif args['output_format'] == 'yml':
-            return send_from_directory(folder, file)
 
 
 class Mapping(Resource):
@@ -52,6 +30,96 @@ class Mapping(Resource):
         folder = os.path.dirname(file_path)
         file = os.path.basename(file_path)
 
+        if args['output_format'] == 'json':
+            return jsonify(yaml.load(open(file_path)))
+
+        elif args['output_format'] == 'yml':
+            return send_from_directory(folder, file)
+
+
+class Schemas(Resource):
+    '''
+    Restful API dealing with databases schemas.
+    '''
+
+    def __init__(self):
+        '''
+        Inits instance parameters.
+        '''
+
+        self.url = 'http://127.0.0.1:8421'
+
+    def get(self, **kwargs):
+        '''
+        Calls resource's method depending on the number
+        of arguemnts.
+        '''
+
+        if len(kwargs) == 0:
+            return self.get_list()
+        elif len(kwargs) == 2:
+            return self.get_schema(**kwargs)
+
+        return jsonify({
+            'message': 'Invalid number of arguments',
+        })
+
+    def get_list(self):
+        '''
+        Fetches CSV from distant source and builds
+        a flask response.
+        '''
+
+        content = requests.get('{}/databases.csv'.format(
+            self.url
+        )).content
+
+        response = make_response(content)
+        cd = 'attachment; filename=databases.csv'
+        response.headers['Content-Disposition'] = cd
+        response.mimetype = 'text/csv'
+
+        return response
+
+    def get_schema(self, database_name, extension):
+        '''
+        Fetches distant file and parses it according
+        to its extension.
+        '''
+
+        content = requests.get('{}/{}.{}'.format(
+            self.url,
+            database_name,
+            extension
+        )).content
+
+        if extension == 'json':
+            return jsonify(json.loads(content))
+        elif extension == 'yml':
+            return jsonify(yaml.load(content))
+
+        return jsonify({
+            'message': 'Unknown extension.'
+        })
+
+
+class Store(Resource):
+    def post(self):
+
+        parser = reqparse.RequestParser()
+        parser.add_argument('output_format', required=True, type=str, choices=('json', 'yml'))
+        parser.add_argument('fhir_resource_name', required=True, type=str)
+
+        args = parser.parse_args()
+
+        file_path = fhir_resource_path(args['fhir_resource_name'], parent_folder=args['output_format'])
+        if not file_path:
+            return jsonify(
+                {"message": "Fhir resource not found."}
+            )
+
+        folder = os.path.dirname(file_path)
+        file = os.path.basename(file_path)
         if args['output_format'] == 'json':
             return jsonify(yaml.load(open(file_path)))
 

--- a/api/resources/resources.py
+++ b/api/resources/resources.py
@@ -24,10 +24,11 @@ class Mapping(Resource):
         args = parser.args()
 
         file_path = fhir_resource_path(args['fhir_resource_name'], parent_folder=args['database'])
+
         if not file_path:
-            return jsonify(
-                {"message": "Fhir resource not found."}
-            )
+            return jsonify({
+                "message": "Fhir resource not found.",
+            })
 
         folder = os.path.dirname(file_path)
         file = os.path.basename(file_path)
@@ -36,6 +37,10 @@ class Mapping(Resource):
             return jsonify(yaml.load(open(file_path)))
         elif args['output_format'] == 'yml':
             return send_from_directory(folder, file)
+
+        return jsonify({
+            'message': 'Extension not found.'
+        })
 
 
 class Schemas(Resource):
@@ -82,15 +87,20 @@ class Store(Resource):
         args = parser.parse_args()
 
         file_path = fhir_resource_path(args['fhir_resource_name'], parent_folder=args['output_format'])
+
         if not file_path:
-            return jsonify(
-                {"message": "Fhir resource not found."}
-            )
+            return jsonify({
+                "message": "Fhir resource not found."
+            })
 
         folder = os.path.dirname(file_path)
         file = os.path.basename(file_path)
+
         if args['output_format'] == 'json':
             return jsonify(yaml.load(open(file_path)))
-
         elif args['output_format'] == 'yml':
             return send_from_directory(folder, file)
+
+        return jsonify({
+            'message': 'Extension not found.',
+        })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=0.12.3
-api==0.0.7
-flask_restful==0.3.6
+requests==2.18.4
+Flask==1.0.2
+Flask_RESTful==0.3.6
 PyYAML==3.13

--- a/server.py
+++ b/server.py
@@ -1,31 +1,20 @@
 from flask import Flask, jsonify
 from flask_restful import Api
 import json
-import requests
 
-from api.resources import Mapping, Store
+from api.resources import Mapping, Schemas, Store
 
 
 app = Flask(__name__)
 api = Api(app)
 
 api.add_resource(Mapping, '/mapping')
+api.add_resource(Schemas,
+    '/schemas/<database_name>/<extension>',
+    '/schemas/list',
+)
+# api.add_resource(Schemas, '/schemas')
 api.add_resource(Store, '/store')
-
-@app.route('/schemas/<database_name>/<extension>', methods=['GET'])
-def get_schema(database_name, extension):
-
-    content = requests.get('http://127.0.0.1:8421/{}.{}'.format(
-        database_name, extension
-    )).content
-
-    return jsonify(json.loads(content))
-
-@app.route('/')
-def index():
-    return jsonify({
-        'message': 'Welcome to Fhir API',
-    })
 
 
 if __name__ == '__main__':

--- a/server.py
+++ b/server.py
@@ -2,18 +2,15 @@ from flask import Flask, jsonify
 from flask_restful import Api
 import json
 
-from api.resources import Mapping, Schemas, Store
+from api.resources import Mapping, Schema, Schemas, Store
 
 
 app = Flask(__name__)
 api = Api(app)
 
 api.add_resource(Mapping, '/mapping')
-api.add_resource(Schemas,
-    '/schemas/<database_name>/<extension>',
-    '/schemas/list',
-)
-# api.add_resource(Schemas, '/schemas')
+api.add_resource(Schema, '/schema/<database_name>/<extension>')
+api.add_resource(Schemas, '/schemas')
 api.add_resource(Store, '/store')
 
 

--- a/server.py
+++ b/server.py
@@ -1,5 +1,7 @@
 from flask import Flask, jsonify
 from flask_restful import Api
+import json
+import requests
 
 from api.resources import Mapping, Store
 
@@ -7,14 +9,23 @@ from api.resources import Mapping, Store
 app = Flask(__name__)
 api = Api(app)
 
-api.add_resource(Store, '/store')
 api.add_resource(Mapping, '/mapping')
+api.add_resource(Store, '/store')
+
+@app.route('/schemas/<database_name>/<extension>', methods=['GET'])
+def get_schema(database_name, extension):
+
+    content = requests.get('http://127.0.0.1:8421/{}.{}'.format(
+        database_name, extension
+    )).content
+
+    return jsonify(json.loads(content))
 
 @app.route('/')
 def index():
-    return jsonify(
-        {'message': 'Welcome to Fhir API'}
-    )
+    return jsonify({
+        'message': 'Welcome to Fhir API',
+    })
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In this PR:
- new flask resource for fetching database schemas
- two `GET` endpoints: one that returns a list of available database schemas, the second for actually fetching a given schema